### PR TITLE
Implement related tabs on show pages

### DIFF
--- a/src/components/Properties/List.svelte
+++ b/src/components/Properties/List.svelte
@@ -5,7 +5,7 @@
   import { Filter, Id, Link, Title, Typeset } from '../Shared'
 
   const index = list(properties(), {
-    weights: { name: 0.7, description: 0.3 },
+    weights: { name: 0.7, aliases: 0.7, description: 0.3 },
     queryParam: 'filter',
   })
 </script>

--- a/src/components/Properties/Show.svelte
+++ b/src/components/Properties/Show.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { properties } from '../../context'
-  import { Title, Typeset } from '../Shared'
+  import { Aliases, References, Tabs, Title, Typeset } from '../Shared'
+  import Theorems from './Theorems.svelte'
 
   export let id: string
 
@@ -13,7 +14,24 @@
 
   <h1>
     <Typeset body={property.name} />
+    {#if property?.aliases}
+      <Aliases aliases={property.aliases} />
+    {/if}
   </h1>
 
   <Typeset body={property.description} />
+
+  <Tabs.Tabs initial="theorems">
+    <Tabs.Nav>
+      <Tabs.Link to="theorems">Theorems</Tabs.Link>
+      <Tabs.Link to="references">References</Tabs.Link>
+    </Tabs.Nav>
+
+    <Tabs.Tab path="theorems">
+      <Theorems {property} />
+    </Tabs.Tab>
+    <Tabs.Tab path="references">
+      <References references={property.refs} />
+    </Tabs.Tab>
+  </Tabs.Tabs>
 {/if}

--- a/src/components/Properties/Theorems.svelte
+++ b/src/components/Properties/Theorems.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+  import * as F from '@pi-base/core/lib/Formula'
+
+  import { Formula, Link, Id } from '../Shared'
+  import type { Property } from '../../types'
+  import { theorems } from '../../context'
+
+  export let property: Property
+
+  const store = theorems()
+
+  $: related = $store.all.filter(
+    ({ when, then }) =>
+      F.properties(when).has(property) || F.properties(then).has(property),
+  )
+</script>
+
+<table class="table">
+  <thead>
+    <tr>
+      <th>Id</th>
+      <th>When</th>
+      <th>Then</th>
+    </tr>
+  </thead>
+  <tbody>
+    {#each related as { uid, when, then } (uid)}
+      <tr>
+        <td>
+          <Link to="/properties/{uid}">
+            <Id {uid} />
+          </Link>
+        </td>
+        <td>
+          <Formula value={when} />
+        </td>
+        <td>
+          <Formula value={then} />
+        </td>
+      </tr>
+    {/each}
+  </tbody>
+</table>

--- a/src/components/Routes.svelte
+++ b/src/components/Routes.svelte
@@ -9,9 +9,9 @@
 </script>
 
 <Route path="/properties" component={Properties.List} />
-<Route path="/properties/:id" component={Properties.Show} />
+<Route path="/properties/:id/*" component={Properties.Show} />
 <Route path="/theorems" component={Theorems.List} />
-<Route path="/theorems/:id" component={Theorems.Show} />
+<Route path="/theorems/:id/*" component={Theorems.Show} />
 <Route path="/dev" component={Dev.Settings} />
 <Route path="/dev/preview" component={Dev.Preview} />
 <Route path="/" component={Home} />

--- a/src/components/Shared/Aliases.svelte
+++ b/src/components/Shared/Aliases.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  import Typeset from './Typeset.svelte'
+
+  export let aliases: string[]
+</script>
+
+{#if aliases.length > 0}
+  <small>
+    <span class="text-muted">or</span>
+    {#each aliases as alias, i (i)}
+      <Typeset body={alias} />
+      {#if i !== aliases.length - 1}<span class="text-muted comma">,</span>{/if}
+    {/each}
+  </small>
+{/if}

--- a/src/components/Shared/Reference.svelte
+++ b/src/components/Shared/Reference.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+  import type { Ref } from '@pi-base/core'
+  import { tag } from '@pi-base/core/lib/Ref'
+  import { format } from '../../parser/externalLinks'
+
+  export let reference: Ref
+
+  $: value = format(tag(reference))
+</script>
+
+{#if value}
+  <a href={value.href}>{value.label}</a>
+{:else}Invalid reference: <code>{JSON.stringify(reference)}</code>{/if}

--- a/src/components/Shared/References.svelte
+++ b/src/components/Shared/References.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  import type { Ref } from '@pi-base/core'
+  import Reference from './Reference.svelte'
+
+  export let references: Ref[]
+</script>
+
+<ul>
+  {#each references as reference, i (i)}
+    <li>
+      <Reference {reference} />
+    </li>
+  {/each}
+</ul>

--- a/src/components/Shared/Tabs/Link.svelte
+++ b/src/components/Shared/Tabs/Link.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+  import { Link } from 'svelte-routing'
+  import { getContext } from 'svelte'
+
+  export let to: string
+
+  const initial = getContext('TABS.INITIAL')
+
+  function getProps({
+    isCurrent,
+    href,
+    location,
+  }: {
+    isCurrent: boolean
+    href: string
+    location: Location
+  }) {
+    const active =
+      isCurrent || (to === initial && href === `${location.pathname}/${to}`)
+    return {
+      class: `nav-link ${active ? 'active' : ''}`,
+    }
+  }
+</script>
+
+<li class="nav-item">
+  <Link {to} {getProps}>
+    <slot />
+  </Link>
+</li>

--- a/src/components/Shared/Tabs/Nav.svelte
+++ b/src/components/Shared/Tabs/Nav.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+</script>
+
+<ul class="nav nav-tabs">
+  <slot />
+</ul>

--- a/src/components/Shared/Tabs/Tab.svelte
+++ b/src/components/Shared/Tabs/Tab.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  import { getContext } from 'svelte'
+  import { Route } from 'svelte-routing'
+
+  export let path: string
+  const initial = getContext('TABS.INITIAL')
+</script>
+
+{#if path === initial}
+  <!-- Fallback route to this tab as well -->
+  <Route>
+    <slot />
+  </Route>
+{:else}
+  <Route {path}>
+    <slot />
+  </Route>
+{/if}

--- a/src/components/Shared/Tabs/Tabs.svelte
+++ b/src/components/Shared/Tabs/Tabs.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+  import { Router } from 'svelte-routing'
+  import { setContext } from 'svelte'
+
+  export let initial: string
+  setContext('TABS.INITIAL', initial)
+</script>
+
+<Router>
+  <slot />
+</Router>

--- a/src/components/Shared/Tabs/index.ts
+++ b/src/components/Shared/Tabs/index.ts
@@ -1,0 +1,4 @@
+export { default as Link } from './Link.svelte'
+export { default as Nav } from './Nav.svelte'
+export { default as Tab } from './Tab.svelte'
+export { default as Tabs } from './Tabs.svelte'

--- a/src/components/Shared/index.ts
+++ b/src/components/Shared/index.ts
@@ -1,8 +1,12 @@
 export { Link } from 'svelte-routing'
 
+export * as Tabs from './Tabs/index'
+
 export { default as Age } from './Age.svelte'
+export { default as Aliases } from './Aliases.svelte'
 export { default as Filter } from './Filter.svelte'
 export { default as Formula } from './Formula.svelte'
 export { default as Id } from './Id.svelte'
+export { default as References } from './References.svelte'
 export { default as Title } from './Title.svelte'
 export { default as Typeset } from './Typeset.svelte'

--- a/src/components/Theorems/Show.svelte
+++ b/src/components/Theorems/Show.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { theorems } from '../../context'
-  import { Formula, Title, Typeset } from '../Shared'
+  import { Formula, References, Tabs, Title, Typeset } from '../Shared'
 
   export let id: string
 
@@ -18,4 +18,14 @@
   </h1>
 
   <Typeset body={theorem.description} />
+
+  <Tabs.Tabs initial="references">
+    <Tabs.Nav>
+      <Tabs.Link to="references">References</Tabs.Link>
+    </Tabs.Nav>
+
+    <Tabs.Tab path="references">
+      <References references={theorem.refs} />
+    </Tabs.Tab>
+  </Tabs.Tabs>
 {/if}

--- a/src/parser/externalLinks.ts
+++ b/src/parser/externalLinks.ts
@@ -3,29 +3,41 @@ export default function externalLinks({ citation }: { citation?: string }) {
     return
   }
 
-  const [prefix, id] = citation.split(':', 2)
-  switch (prefix) {
+  const [kind, id] = citation.split(':', 2)
+  return format({ kind, id })
+}
+
+export function format({
+  kind,
+  id,
+  name,
+}: {
+  kind: string
+  id: string
+  name?: string
+}): { href: string; label: string } | undefined {
+  switch (kind) {
     case 'doi':
-      return { href: `https://doi.org/${id}`, label: `DOI ${id}` }
+      return { href: `https://doi.org/${id}`, label: name || `DOI ${id}` }
     case 'mr':
       return {
         href: `https://mathscinet.ams.org/mathscinet-getitem?mr=${id}`,
-        label: `MR ${id}`,
+        label: name || `MR ${id}`,
       }
     case 'wikipedia':
       return {
         href: `https://en.wikipedia.org/wiki/${id}`,
-        label: `Wikipedia ${id}`,
+        label: name || `Wikipedia ${id}`,
       }
     case 'mathse':
       return {
         href: `https://math.stackexchange.com/questions/${id}`,
-        label: `Math StackExchange ${id}`,
+        label: name || `Math StackExchange ${id}`,
       }
     case 'mo':
       return {
         href: `https://mathoverflow.net/questions/${id}`,
-        label: `MathOverflow ${id}`,
+        label: name || `MathOverflow ${id}`,
       }
   }
 }


### PR DESCRIPTION
* [x] Add subtab navigation
* [x] Implement shared references tab
* [x] Implement "related theorems" for property page

The other tabs (`property > spaces` and `theorem > converse`) require interacting with traits, which will be implemented in future work.